### PR TITLE
fix: modified behavior when lbo type is lbo_before

### DIFF
--- a/lbo-rules.go
+++ b/lbo-rules.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2023 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package linebreak
+
+var lboBreaks = []rune{
+	0x0a, // LF
+	0x0d, // CR
+}
+
+// https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages
+
+var lboBefores = []rune{
+	0x0028, // (
+	0x005B, // [
+	0x007B, // {
+	0x00AB, // «
+	0x3008, // 〈
+	0x300A, // 《
+	0x300C, // 「
+	0x300E, // 『
+	0x3010, // 【
+	0x3014, // 〔
+	0x3016, // 〖
+	0x3018, // 〘
+	0x301D, // 〝
+	0xFF5F, // ｟
+}
+
+var lboAfters = []rune{
+	0x0021, // !
+	0x0029, // )
+	0x002C, // ,
+	0x002E, // .
+	0x002F, // /
+	0x003A, // :
+	0x003B, // ;
+	0x003F, // ?
+	0x30A0, // ゠
+	0x30A1, // ァ
+	0x30A3, // ィ
+	0x30A5, // ゥ
+	0x30A7, // ェ
+	0x30A9, // ォ
+	0x30C3, // ッ
+	0x30E3, // ャ
+	0x30E5, // ュ
+	0x30E7, // ョ
+	0x30EE, // ヮ
+	0x30F5, // ヵ
+	0x30F6, // ヶ
+	0x3041, // ぁ
+	0x3043, // ぃ
+	0x3045, // ぅ
+	0x3047, // ぇ
+	0x3049, // ぉ
+	0x3063, // っ
+	0x3083, // ゃ
+	0x3085, // ゅ
+	0x3087, // ょ
+	0x308E, // ゎ
+	0x3095, // ゕ
+	0x3096, // ゖ
+	0x30FC, // ー
+	0x3001, // 、
+	0x3002, // 。
+	0x3005, // 々
+	0x3008, // 〈
+	0x3009, // 〉
+	0x300A, // 《
+	0x300B, // 》
+	0x300C, // 「
+	0x300D, // 」
+	0x300E, // 』
+	0x300F, // 】
+	0x3015, // 〕
+	0x3017, // 〗
+	0x3019, // 〙
+	0x301F, // 〟
+	0xFF09, // )
+	0xFF5D, // ｝
+}

--- a/line-iter_test.go
+++ b/line-iter_test.go
@@ -418,12 +418,139 @@ func TestLineIter_lineBreaksOfEastAsianWideLetter(t *testing.T) {
 	assert.Equal(t, line, "す。")
 }
 
+func TestLineIter_prohibitionsOfLineBreakOfJapanese_start(t *testing.T) {
+	text := "句読点は、行頭に置くことは禁止である。"
+	iter := linebreak.New(text, 8)
+
+	line, more := iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "句読点")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "は、行頭")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "に置くこ")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "とは禁止")
+
+	line, more = iter.Next()
+	assert.False(t, more)
+	assert.Equal(t, line, "である。")
+}
+
+func TestLineIter_prohibitionsOfLineBreakOfJapanese_end(t *testing.T) {
+	text := "開き括弧は「行末に置く」ことは禁止である。"
+	iter := linebreak.New(text, 12)
+
+	line, more := iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "開き括弧は")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "「行末に置")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "く」ことは禁")
+
+	line, more = iter.Next()
+	assert.False(t, more)
+	assert.Equal(t, line, "止である。")
+}
+
+func TestLineIter_prohibitionsOfLineBreakOfEnglish(t *testing.T) {
+	text := "abc def ghi(jkl mn opq rst uvw xyz)"
+	iter := linebreak.New(text, 11)
+
+	line, more := iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "abc def ghi")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "(jkl mn opq")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "rst uvw")
+
+	line, more = iter.Next()
+	assert.False(t, more)
+	assert.Equal(t, line, "xyz)")
+}
+
+func TestLineIter_prohibitionsOfLineBreakOfEnglish_quots(t *testing.T) {
+	text := `abc def " ghi j " kl mno pq" rst uvw" xyz`
+	iter := linebreak.New(text, 9)
+
+	line, more := iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "abc def")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "\" ghi j \"")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "kl mno pq")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "\" rst")
+
+	line, more = iter.Next()
+	assert.False(t, more)
+	assert.Equal(t, line, "uvw\" xyz")
+}
+
+func TestLineIter_prohibitionsOfLineBreakOfEnglish_mixedQuots(t *testing.T) {
+	text := `abc def " ghi j ' kl mno pq' rst uvw" xyz`
+	iter := linebreak.New(text, 9)
+
+	line, more := iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "abc def")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "\" ghi j")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "' kl mno")
+
+	line, more = iter.Next()
+	assert.True(t, more)
+	assert.Equal(t, line, "pq' rst")
+
+	line, more = iter.Next()
+	assert.False(t, more)
+	assert.Equal(t, line, "uvw\" xyz")
+
+	iter = linebreak.New(text, 9)
+
+	for {
+		line, more := iter.Next()
+		fmt.Println(line)
+		if !more {
+			break
+		}
+	}
+}
+
 func TestLineIter_japanese(t *testing.T) {
 	text := "私はその人を常に先生と呼んでいた。だからここでもただ先生と書くだ" +
 		"けで本名は打ち明けない。これは世間を憚かる遠慮というよりも、その方が私" +
 		"にとって自然だからである。私はその人の記憶を呼び起すごとに、すぐ「先生" +
 		"」といいたくなる。筆を執っても心持は同じ事である。よそよそしい頭文字な" +
-		"どはとても使う気にならない。"
+		"どはとても使う気にならない。\n（夏目漱石「こころ」から引用）"
 
 	iter := linebreak.New(text, 50)
 


### PR DESCRIPTION
This PR fixes the behavior of line break when line break opportunity is `lbo_before`.
This PR adds the mechanism of line break for `lbo_before` and the line breaking rules in Japanese  ("kinsoku syori").

About line breaking rules, this modification is a provisional solution before supporting UAX 14.