### PR TITLE
update: modified some APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import "github.com/sttk/linebreak"
 The following code breaks the argument text into lines within the terminal width, and outputs them to stdout.
 
 ```
-iter := linebreak.New(text, linebreak.TermWidth())
+iter := linebreak.New(text, linebreak.TermCols())
 for {
 	line, more := iter.Next()
 	fmt.Println(line)

--- a/example_line-iter_test.go
+++ b/example_line-iter_test.go
@@ -2,6 +2,8 @@ package linebreak_test
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/sttk/linebreak"
 )
 
@@ -45,7 +47,7 @@ func ExampleLineIter_SetIndent() {
 
 	if more {
 		for i := 1; ; i++ {
-			iter.SetIndent(linebreak.Spaces(i * 2))
+			iter.SetIndent(strings.Repeat(" ", i*2))
 			line, more := iter.Next()
 			fmt.Println(line)
 			if !more {

--- a/internal_test.go
+++ b/internal_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestRuneWidth(t *testing.T) {
-	assert.Equal(t, runeWidth('a'), 1)
-	assert.Equal(t, runeWidth('あ'), 2)
-	assert.Equal(t, runeWidth('ｱ'), 1)
+	assert.Equal(t, RuneWidth('a'), 1)
+	assert.Equal(t, RuneWidth('あ'), 2)
+	assert.Equal(t, RuneWidth('ｱ'), 1)
 }
 
 func TestTrimRight(t *testing.T) {

--- a/line-iter.go
+++ b/line-iter.go
@@ -31,8 +31,8 @@ type lboState struct {
 	openQuot int8 // 0:not, 1:opened, 2:opened inside '...'
 }
 
-// LineIter is the struct that output the given string line by line.
-// This struct can control the overall line witdh and the indentation from any
+// LineIter is the struct that outputs the given string line by line.
+// This struct can control the overall line width and the indentation from any
 // desired line.
 type LineIter struct {
 	scanner  *scanner.Scanner
@@ -64,7 +64,7 @@ func (iter *LineIter) SetIndent(indent string) {
 	iter.indent = indent
 }
 
-// Init is the method to re-initialize with an argument string and reuse this
+// Init is the method to re-initialize with an argument string for reusing this
 // instance.
 func (iter *LineIter) Init(text string) {
 	iter.scanner.Init(strings.NewReader(text))
@@ -76,7 +76,7 @@ func (iter *LineIter) Init(text string) {
 	iter.openApos = 0
 }
 
-// Next is the method that returns a string of a next line and a bool which
+// Next is the method that returns a string of the next line and a bool which
 // indicates whether there are more next lines or not.
 func (iter *LineIter) Next() (string, bool) {
 	limit := iter.limit - len(iter.indent)
@@ -108,7 +108,7 @@ func (iter *LineIter) Next() (string, bool) {
 			continue
 		}
 
-		runeW := runeWidth(r)
+		runeW := RuneWidth(r)
 		lboPos := iter.lboPos
 
 		if (iter.width[0] + iter.width[1] + runeW) > limit {
@@ -273,21 +273,6 @@ func contains(candidates []rune, r rune) bool {
 		}
 	}
 	return false
-}
-
-func runeWidth(r rune) int {
-	if !unicode.IsPrint(r) {
-		return 0
-	}
-
-	switch width.LookupRune(r).Kind() {
-	case width.EastAsianNarrow, width.EastAsianHalfwidth, width.Neutral:
-		return 1
-	case width.EastAsianWide, width.EastAsianFullwidth:
-		return 2
-	default: // width.EastAsianAmbiguous
-		return 2
-	}
 }
 
 func trimRight(runes []rune) []rune {

--- a/utils.go
+++ b/utils.go
@@ -6,16 +6,18 @@ package linebreak
 
 import (
 	"os"
-	"strings"
+	"unicode"
 
 	"golang.org/x/term"
+	"golang.org/x/text/width"
 )
 
-// TermWidth is the function that returns terminal width.
-// The width is the count of ASCII printable character.
-// If it failed to get terminal width, this function returns the fixed number:
+// TermCols is the function that returns the column count of the current
+// terminal.
+// This count is the number of ASCII printable characters.
+// If it failed to get the count, this function returns the fixed number:
 // 80.
-func TermWidth() int {
+func TermCols() int {
 	w, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		w = 80
@@ -23,24 +25,48 @@ func TermWidth() int {
 	return w
 }
 
-// TextWidth is the function that calculates a text width.
+// TermSize is the function that returns the column count and row count of the
+// current terminal.
+// These counts are the numbers of ASCII printable characters.
+// If it failed to get these counts, this function returns the fixed numbers:
+// 80 columns and 24 rows..
+func TermSize() (cols, rows int) {
+	var err error
+	cols, rows, err = term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		cols = 80
+		rows = 24
+	}
+	return
+}
+
+// RuneWidth is the function that returns the display width of the specified
+// rune.
+// A display width is determined by the Unicode Standard Annex #11 (UAX11)
+// East-Asian-Width.
+func RuneWidth(r rune) int {
+	if !unicode.IsPrint(r) {
+		return 0
+	}
+
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianNarrow, width.EastAsianHalfwidth, width.Neutral:
+		return 1
+	case width.EastAsianWide, width.EastAsianFullwidth:
+		return 2
+	default: // width.EastAsianAmbiguous
+		return 2
+	}
+}
+
+// TextWidth is the function that returns the display width of the spe
 // This function calculates the width of the specified text taking into
 // account the letter width determined by the Unicode Standard Annex #11
 // (UAX11) East-Asian-Width.
 func TextWidth(text string) int {
 	w := 0
 	for _, r := range text {
-		w += runeWidth(r)
+		w += RuneWidth(r)
 	}
 	return w
-}
-
-// Spaces is the function that generates a consecutive ASCII spaces of which
-// count is specified by the argument.
-// If the count is negative, this function returns an empty strings.
-func Spaces(count int) string {
-	if count < 0 {
-		count = 0
-	}
-	return strings.Repeat(" ", count)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,16 +7,17 @@ import (
 	"github.com/sttk/linebreak"
 )
 
-func TestTermWidth(t *testing.T) {
-	assert.Equal(t, linebreak.TermWidth(), 80)
+func TestTermCols(t *testing.T) {
+	assert.Equal(t, linebreak.TermCols(), 80)
+}
+
+func TestTermSize(t *testing.T) {
+	cols, rows := linebreak.TermSize()
+	assert.Equal(t, cols, 80)
+	assert.Equal(t, rows, 24)
 }
 
 func TestTextWidth(t *testing.T) {
 	assert.Equal(t, linebreak.TextWidth("abc"), 3)
 	assert.Equal(t, linebreak.TextWidth("あいう"), 6)
-}
-
-func TestSpaces(t *testing.T) {
-	assert.Equal(t, linebreak.Spaces(3), "   ")
-	assert.Equal(t, linebreak.Spaces(-1), "")
 }


### PR DESCRIPTION
This PR modifies some APIs' declarations as follows:

- Removes `linebreak.Spaces`.
- Renames `linebreak.runeWidth` to `linebreak.RuneWidth`, and makes it public.
- Renames `linebreak.TermWidth` to `linebreak.TermCols`.
- Adds `linebreak.TermSize`.