### PR TITLE
fix: corrected bugs in lineBreakOpportunity

### DIFF
--- a/line-iter.go
+++ b/line-iter.go
@@ -88,7 +88,7 @@ func (iter *LineIter) Next() (string, bool) {
 	state.openApos = iter.openApos
 
 	for r := iter.scanner.Next(); r != scanner.EOF; r = iter.scanner.Next() {
-		lineBreakOppotunity(r, &state)
+		lineBreakOpportunity(r, &state)
 
 		if state.lboType == lbo_break {
 			line = string(trimRight(iter.buffer.full()))
@@ -207,7 +207,7 @@ func (iter *LineIter) Next() (string, bool) {
 	return line, false
 }
 
-func lineBreakOppotunity(r rune, state *lboState) {
+func lineBreakOpportunity(r rune, state *lboState) {
 	state.lboPrev = state.lboType
 
 	switch r {
@@ -216,10 +216,10 @@ func lineBreakOppotunity(r rune, state *lboState) {
 			state.openQuot = state.openApos + 1
 			state.lboType = lbo_before
 		} else { // close
-			state.openQuot = 0
 			if state.openQuot < state.openApos {
 				state.openApos = 0
 			}
+			state.openQuot = 0
 			state.lboType = lbo_after
 		}
 		return
@@ -228,10 +228,10 @@ func lineBreakOppotunity(r rune, state *lboState) {
 			state.openApos = state.openQuot + 1
 			state.lboType = lbo_before
 		} else { // close
-			state.openApos = 0
 			if state.openApos < state.openQuot {
 				state.openQuot = 0
 			}
+			state.openApos = 0
 			state.lboType = lbo_after
 		}
 		return

--- a/line-iter_test.go
+++ b/line-iter_test.go
@@ -61,7 +61,7 @@ func TestLineIter_Next_equalToLineWidth(t *testing.T) {
 	assert.Equal(t, line, "")
 }
 
-func TestLineIter_Next_breakAtLineBreakOppotunity(t *testing.T) {
+func TestLineIter_Next_breakAtLineBreakOpportunity(t *testing.T) {
 	text := "1234567890 abcdefghij"
 	iter := linebreak.New(text, 20)
 
@@ -121,7 +121,7 @@ func TestLineIter_Next_removeSpacesOfAllSpaceLine(t *testing.T) {
 	assert.Equal(t, line, "")
 }
 
-func TestLineIter_Next_thereIsNoLineBreakOppotunity(t *testing.T) {
+func TestLineIter_Next_thereIsNoLineBreakOpportunity(t *testing.T) {
 	text := "12345678901234567890abcdefghij"
 	iter := linebreak.New(text, 20)
 


### PR DESCRIPTION
Closes #15

This PR fixes bugs in `lineBreakOpportunity` function. 
`openApos` or `openQuot` had been cleared before comparison between them.

And there were typo of `Opportunity` as `Oppotunity`.

