### PR TITLE
doc: updated actual test results in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,31 +47,43 @@ This library supports Go 1.18 or later.
 % gvm-fav
 Now using version go1.18.10
 go version go1.18.10 darwin/amd64
-ok  	github.com/sttk/linebreak	0.516s	coverage: 95.6% of statements
+ok  	github.com/sttk/linebreak	0.458s	coverage: 95.6% of statements
 
 Now using version go1.19.13
 go version go1.19.13 darwin/amd64
-ok  	github.com/sttk/linebreak	0.510s	coverage: 95.6% of statements
+ok  	github.com/sttk/linebreak	0.459s	coverage: 95.6% of statements
 
 Now using version go1.20.14
 go version go1.20.14 darwin/amd64
-ok  	github.com/sttk/linebreak	0.521s	coverage: 95.6% of statements
+ok  	github.com/sttk/linebreak	0.465s	coverage: 95.6% of statements
 
 Now using version go1.21.13
 go version go1.21.13 darwin/amd64
-ok  	github.com/sttk/linebreak	0.527s	coverage: 95.6% of statements
+ok  	github.com/sttk/linebreak	0.468s	coverage: 95.6% of statements
 
-Now using version go1.22.6
-go version go1.22.6 darwin/amd64
-ok  	github.com/sttk/linebreak	0.521s	coverage: 95.6% of statements
+Now using version go1.22.12
+go version go1.22.12 darwin/amd64
+ok  	github.com/sttk/linebreak	0.470s	coverage: 95.6% of statements
 
-Back to go1.22.6
-Now using version go1.22.6
+Now using version go1.23.10
+go version go1.23.10 darwin/amd64
+ok  	github.com/sttk/linebreak	0.473s	coverage: 95.6% of statements
+
+Now using version go1.24.6
+go version go1.24.6 darwin/amd64
+ok  	github.com/sttk/linebreak	0.483s	coverage: 95.6% of statements
+
+Now using version go1.25.0
+go version go1.25.0 darwin/amd64
+ok  	github.com/sttk/linebreak	0.476s	coverage: 95.6% of statements
+
+Back to go1.25.0
+Now using version go1.25.0
 ```
 
 ## License
 
-Copyright (C) 2023-2024 Takayuki Sato
+Copyright (C) 2023-2025 Takayuki Sato
 
 This program is free software under MIT License.<br>
 See the file LICENSE in this distribution for more details.
@@ -81,6 +93,6 @@ See the file LICENSE in this distribution for more details.
 [pkg-dev-img]: https://pkg.go.dev/badge/github.com/sttk/linebreak.svg
 [pkg-dev-url]: https://pkg.go.dev/github.com/sttk/linebreak
 [ci-img]: https://github.com/sttk/linebreak/actions/workflows/go.yml/badge.svg?branch=main
-[ci-url]: https://github.com/sttk/linebreak/actions
+[ci-url]: https://github.com/sttk/linebreak/actions?query=branch%3Amain
 [mit-img]: https://img.shields.io/badge/license-MIT-green.svg
 [mit-url]: https://opensource.org/licenses/MIT


### PR DESCRIPTION
This PR expands the go versions of actual test results in `README.md` to `1.25`.

And this PR modifies the link to github actions results only for `main` branch.